### PR TITLE
Javascript changes to set focus on error text element in all browsers

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -29,6 +29,14 @@ $(document).ready(function () {
         $(document).scrollTop(errorSummary.offset().top);
         $(errorSummary).focus();
     }
+
+    //The focus setting behaviour defined in Assests is having troubles with different browsers. So we need to override the behaviour to make it work across all browsers
+    $('.error-summary a').on('click', function (e) {
+        e.preventDefault()
+        var $this = $(this);
+        var focusId = $this.attr('data-focuses');
+        $('[id="'+focusId +'"]').trigger('focus'); //This is needed as we have '.' inside the focusId value
+    })
 });
 
 window.onload = function () {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -35,7 +35,14 @@ $(document).ready(function () {
         e.preventDefault()
         var $this = $(this);
         var focusId = $this.attr('data-focuses');
-        $('[id="'+focusId +'"]').trigger('focus'); //This is needed as we have '.' inside the focusId value
+        var fieldTypeVal = $('[id="'+focusId +'"]').prop('type');
+
+        if(fieldTypeVal == 'fieldset') {
+            $('[id="'+focusId + '-true'   + '"]').trigger('focus'); //This is to deal with fieldset properties
+        }
+        else {
+            $('[id="'+ focusId + '"]').trigger('focus'); //This is to deal with remaining types of elements
+        }
     })
 });
 


### PR DESCRIPTION
Added jQuery code to deal with click on errors event. The focus is now set on error element correctly across the browsers Chrome and Firefox.
This still needs to be tested in Safari.
